### PR TITLE
Change regex to greedy and allow non-whitespace

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -63,7 +63,7 @@ const extractCommand = (message, commands) => {
 
 const extractPlusMinusEventData = (text) => {
   
-  const data = text.match(/@([A-Za-z0-9:-_]+?)>?\s*(\+{2}|-{2}|—{1}|={2}|#{2})/);
+  const data = text.match(/@(\S+)>?\s*(\+{2}|-{2}|—{1}|={2}|#{2})/);
 
 
   if (!data) {


### PR DESCRIPTION
IE, set it up to allow `@thing++++` where `thing++` get's `++`'d 

or `@¯\_(ツ)_/¯++` where `¯\_(ツ)_/¯` gets `++`'d